### PR TITLE
Using hardcoded yarn 0.16.1 version

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -11,7 +11,7 @@ install_yarn() {
   local dir="$1"
 
   echo "Downloading and installing yarn..."
-  local download_url="https://yarnpkg.com/latest.tar.gz"
+  local download_url="https://github.com/yarnpkg/yarn/releases/download/v0.16.1/yarn-v0.16.1.tar.gz"
   local code=$(curl "$download_url" -L --silent --fail --retry 5 --retry-max-time 15 -o /tmp/yarn.tar.gz --write-out "%{http_code}")
   if [ "$code" != "200" ]; then
     echo "Unable to download yarn: $code" && false


### PR DESCRIPTION
# What's up

This PR is just used as a reference to show what changed in order to use the v0.16.1 yarn version. It will not be merged into master. PR is just to see the diff and to point it out to other people.

Once this problem has been resolved we can go back to the original heroku-buildpack-nodejs buildpack instead of using our own fork.

